### PR TITLE
feat: CODEOWNERSファイルを追加してブランチ保護を強化

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Global code owners
+* @bonjinnorenka
+
+# TypeScript source code
+src/ @bonjinnorenka
+
+# Configuration files
+*.json @bonjinnorenka
+*.md @bonjinnorenka
+
+# GitHub workflows
+.github/ @bonjinnorenka


### PR DESCRIPTION
## Summary
- GitHubのブランチ保護設定でコードオーナーレビューを有効化
- CODEOWNERSファイルを追加し、全ファイルに対して@bonjinnorenkaの承認を必須に設定
- 他人による直接pushやマージを防止する保護機能を実装

## Test plan
- [ ] CODEOWNERSファイルが正しく配置されている
- [ ] ブランチ保護設定が有効になっている
- [ ] コードオーナーレビューが必須になっている

🤖 Generated with [Claude Code](https://claude.ai/code)